### PR TITLE
Add isRefOrNull() check before deciding if variant is novel.

### DIFF
--- a/src/lib/metrics/Metrics.cpp
+++ b/src/lib/metrics/Metrics.cpp
@@ -384,7 +384,7 @@ void SampleMetrics::processEntry(Vcf::Entry& e, EntryMetrics& m) {
             //determine if novel which is by allele
             std::vector<bool> novelByAlt = m.novelStatusByAlt();
             for(auto j = gt.indexSet().begin(); j != gt.indexSet().end(); ++j) {
-                if(*j == 0)
+                if(isRefOrNull(*j))
                     continue;
                 if(novelByAlt[j->value - 1]) {    //need to subtract one because reference is not an Alt
                     ++_perSampleNovelVariants[sampleIdx];


### PR DESCRIPTION
This was segfaulting when running `joinx vcf-report`.  It seems to work with this change!