### PR TITLE
Explicitly convert istream returned from getline() to bool

### DIFF
--- a/src/lib/io/InputStream.cpp
+++ b/src/lib/io/InputStream.cpp
@@ -75,7 +75,7 @@ bool InputStream::getline(string& line) {
         _cacheIter = _cache.end();
     }
 
-    return _in;
+    return bool(_in);
 }
 
 char InputStream::peek() {

--- a/src/lib/io/InputStream.hpp
+++ b/src/lib/io/InputStream.hpp
@@ -54,5 +54,5 @@ inline bool InputStream::good() const {
 }
 
 inline bool getline(InputStream& s, std::string& line) {
-    return s.getline(line);
+    return bool(s.getline(line));
 }

--- a/src/lib/io/StreamLineSource.cpp
+++ b/src/lib/io/StreamLineSource.cpp
@@ -6,7 +6,7 @@ StreamLineSource::StreamLineSource(std::istream& in)
 }
 
 bool StreamLineSource::getline(std::string& line) {
-    return std::getline(_in, line);
+    return bool(std::getline(_in, line));
 }
 
 char StreamLineSource::peek() {

--- a/test/lib/fileformats/TestVcfEntry.cpp
+++ b/test/lib/fileformats/TestVcfEntry.cpp
@@ -414,7 +414,7 @@ TEST_F(TestVcfEntry, sampleDataPrintCertainSample) {
 TEST_F(TestVcfEntry, multipleFilters) {
     stringstream vcfss(filteredTwiceLine);
     string line;
-    ASSERT_TRUE(getline(vcfss, line));
+    ASSERT_TRUE(bool(getline(vcfss, line)));
     Entry e(&_header, line);
 
     EXPECT_EQ(2u, e.failedFilters().size());
@@ -424,7 +424,7 @@ TEST_F(TestVcfEntry, multipleFilters) {
 TEST_F(TestVcfEntry, multipleFiltersWhitelist) {
     stringstream vcfss(filteredTwiceLine);
     string line;
-    ASSERT_TRUE(getline(vcfss, line));
+    ASSERT_TRUE(bool(getline(vcfss, line)));
     Entry e(&_header, line);
 
     EXPECT_EQ(2u, e.failedFilters().size());


### PR DESCRIPTION
Implicit conversion to bool caused build errors when compiling with GCC 5.4.0.
The reason, if I understand correctly, is that C++11 requires that operator bool() is only usable explicitly (unlike in earlier versions of C++).

Also see issue #13 